### PR TITLE
chore: add attribute game init command 1p and 2p

### DIFF
--- a/prisma/migrations/20240606054955_/migration.sql
+++ b/prisma/migrations/20240606054955_/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `init_1p_command` to the `Game` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `init_2p_command` to the `Game` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Game" ADD COLUMN     "init_1p_command" TEXT NOT NULL,
+ADD COLUMN     "init_2p_command" TEXT NOT NULL;

--- a/prisma/migrations/20240606055508_/migration.sql
+++ b/prisma/migrations/20240606055508_/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `init_1p_command` column on the `Game` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `init_2p_command` column on the `Game` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Game" DROP COLUMN "init_1p_command",
+ADD COLUMN     "init_1p_command" TEXT[],
+DROP COLUMN "init_2p_command",
+ADD COLUMN     "init_2p_command" TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,8 @@ model Game {
   game_name String
   game_info String
   game_command Json
+  init_1p_command String[]
+  init_2p_command String[]
 }
 
 model User {


### PR DESCRIPTION
-prisma orm에서 시작 커맨드를 추가하기 위해 game 테이블에 init command 1p, 2p용 추가

## Pull Request 요약

prisma orm attribute 추가

### 관련 이슈

-게임을 시작할 때 사용자가 편리하게 게임을 시작하게 하기 위해서 1p, 2p에 대한 자동 시작 커맨드가 필요함

## 변경 사항

-prisma orm에서 관련 attribute 추가 및 데이터베이스 테이블 수정

### 변경된 파일

schema.prisma

### 스크린샷 (선택사항)

[필요에 따라 변경 내용을 시각적으로 확인할 수 있는 스크린샷을 여기에 추가하세요.]

## 테스트 계획

[이 변경 사항을 어떻게 테스트할 것인지 설명하세요. 어떤 테스트 케이스를 실행했는지, 어떤 결과를 예상했는지 등을 기술해주세요.]

### 테스트 결과

[실행한 테스트의 결과를 여기에 추가하세요. 성공한 테스트 케이스, 실패한 테스트 케이스 등을 기술해주세요.]

## 리뷰어 참고 사항 (선택사항)

[리뷰어가 참고해야 할 사항이나 특별히 주의해야 할 점이 있다면 여기에 기록하세요.]

## 체크리스트

- [x] 코드는 스타일 가이드에 따라 작성되었습니다.
- [x] 모든 테스트가 통과되었습니다.
- [x] 문서가 업데이트되었습니다.
- [x] 코드 변경이 모든 영향을 고려하여 테스트되었습니다.

## 기타 사항 (선택사항)

[기타 사항이 있다면 여기에 추가하세요.]